### PR TITLE
fix: remove non-applicable tw classes and export style.css

### DIFF
--- a/packages/sado-connect/package.json
+++ b/packages/sado-connect/package.json
@@ -17,6 +17,10 @@
     ".": {
       "import": "./dist/sado-connect.js",
       "require": "./dist/sado-connect.umd.cjs"
+    },
+    "./dist/style.css": {
+      "import": "./dist/style.css",
+      "require": "./dist/style.css"
     }
   },
   "scripts": {

--- a/packages/sado-connect/src/components/SelectWalletModal/index.tsx
+++ b/packages/sado-connect/src/components/SelectWalletModal/index.tsx
@@ -95,7 +95,7 @@ export function SelectWalletModal({
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="panel max-w-md transform p-6 align-middle shadow-xl transition-all">
+              <Dialog.Panel className="panel">
                 <section className="panel-title-container">
                   <Dialog.Title as="h3" className="panel-title">
                     Choose wallet to connect


### PR DESCRIPTION
#### What this PR does / why we need it:
- To remove the non-applicable tailwind classes from panel
- To export `./dist/style.css` from `package.json`