### PR TITLE
feature(useSign): return full response after sign (warning: backward incompatible)

### DIFF
--- a/packages/sado-connect/src/hooks/useSign.tsx
+++ b/packages/sado-connect/src/hooks/useSign.tsx
@@ -4,11 +4,11 @@ import { ordit } from "@sadoprotocol/ordit-sdk";
 import { Psbt } from "bitcoinjs-lib";
 
 interface SignedPsbt {
-  rawTxHex: string,
+  rawTxHex: string;
   psbt: {
-    hex: string,
-    base64: string
-  }
+    hex: string;
+    base64: string;
+  };
 }
 
 export function useSign(): [
@@ -31,16 +31,14 @@ export function useSign(): [
       let signedPsbt: SignedPsbt;
 
       if (wallet === Wallet.UNISAT) {
-        signedPsbt = await ordit.unisat.signPsbt(unsignedPsbt);        
+        signedPsbt = await ordit.unisat.signPsbt(unsignedPsbt);
       } else if (wallet === Wallet.XVERSE) {
         const xverseSignPsbtOptions = {
           psbt: unsignedPsbt,
           network,
           inputs: [],
         };
-        signedPsbt = await ordit.xverse.signPsbt(
-          xverseSignPsbtOptions
-        );        
+        signedPsbt = await ordit.xverse.signPsbt(xverseSignPsbtOptions);
       } else {
         throw new Error("No wallet selected");
       }

--- a/packages/sado-connect/src/hooks/useSign.tsx
+++ b/packages/sado-connect/src/hooks/useSign.tsx
@@ -3,8 +3,16 @@ import { useSadoContext, Wallet } from "../providers/SadoContext";
 import { ordit } from "@sadoprotocol/ordit-sdk";
 import { Psbt } from "bitcoinjs-lib";
 
+interface SignedPsbt {
+  rawTxHex: string,
+  psbt: {
+    hex: string,
+    base64: string
+  }
+}
+
 export function useSign(): [
-  (unsignedPsbtBase64: string) => Promise<string>,
+  (unsignedPsbtBase64: string) => Promise<SignedPsbt>,
   string | null,
   boolean
 ] {
@@ -12,7 +20,7 @@ export function useSign(): [
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
 
-  const sign = async (unsignedPsbtBase64: string): Promise<string> => {
+  const sign = async (unsignedPsbtBase64: string): Promise<SignedPsbt> => {
     setLoading(true);
     try {
       setError(null);
@@ -20,29 +28,27 @@ export function useSign(): [
 
       const unsignedPsbt = Psbt.fromBase64(unsignedPsbtBase64);
 
-      let signedPsbtBase64: string;
+      let signedPsbt: SignedPsbt;
 
       if (wallet === Wallet.UNISAT) {
-        const signedUnisatPsbt = await ordit.unisat.signPsbt(unsignedPsbt);
-        signedPsbtBase64 = signedUnisatPsbt.psbt.base64;
+        signedPsbt = await ordit.unisat.signPsbt(unsignedPsbt);        
       } else if (wallet === Wallet.XVERSE) {
         const xverseSignPsbtOptions = {
           psbt: unsignedPsbt,
           network,
           inputs: [],
         };
-        const signedXversePsbt = await ordit.xverse.signPsbt(
+        signedPsbt = await ordit.xverse.signPsbt(
           xverseSignPsbtOptions
-        );
-        signedPsbtBase64 = signedXversePsbt.psbt.base64;
+        );        
       } else {
         throw new Error("No wallet selected");
       }
-      if (!signedPsbtBase64) {
+      if (!signedPsbt || !signedPsbt.rawTxHex) {
         throw new Error("Signing failed.");
       }
       setLoading(false);
-      return signedPsbtBase64;
+      return signedPsbt;
     } catch (err: any) {
       setError(err.message);
       setLoading(false);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- WARNING: this is a breaking changes, will need downstream to make changes
- In order to relay tx, we will need to use the `rawTxHex` and not the signed psbt

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes ORD-<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes ORD-422

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [ ] No console errors on web
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->
